### PR TITLE
Context menus

### DIFF
--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -1,0 +1,37 @@
+/**
+ * Option to undo previous action.
+ * @alias Blockly.ContextMenuItems.registerUndo
+ */
+ const registerDeletable = function() {
+    /** @type {!ContextMenuRegistry.RegistryItem} */
+    const deletableOption = {
+      displayText: function(scope) {
+        // isDeletale is a built in Blockly function that checks whether the block
+        // is deletable, is not a shadow, and if the workspace is readonly.
+        const displayText = scope.block.isDeletable()
+        ? 'Make Undeletable to Users'
+        : 'Make Deletable to Users',
+        return displayText;
+      },
+      preconditionFn: function() {
+        if (Blockly.isStartMode) {
+          return 'enabled';
+        }
+        return 'hidden';
+      },
+      callback: function(/** @type {!ContextMenuRegistry.Scope} */
+                         scope) {
+        scope.block.setDeletable(!this.isDeletable());
+      },
+      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
+      id: 'blockDeletable',
+      weight: 1,
+    };
+    ContextMenuRegistry.registry.register(deletableOption);
+  };
+
+const registerAllContextMenuItems = function() {
+    registerDeletable();
+}
+exports.registerAllContextMenuItems = registerAllContextMenuItems;
+  

--- a/apps/src/blockly/addons/contextMenu.js
+++ b/apps/src/blockly/addons/contextMenu.js
@@ -1,9 +1,11 @@
+import GoogleBlockly from 'blockly/core';
+
 /**
- * Option to undo previous action.
- * @alias Blockly.ContextMenuItems.registerUndo
+ * Example method that moved the registerDeletable from BlockSvg
+ * customContextMenu to here.
  */
  const registerDeletable = function() {
-    /** @type {!ContextMenuRegistry.RegistryItem} */
+    /** @type {!GoogleBlockly.ContextMenuRegistry.RegistryItem} */
     const deletableOption = {
       displayText: function(scope) {
         // isDeletale is a built in Blockly function that checks whether the block
@@ -19,15 +21,15 @@
         }
         return 'hidden';
       },
-      callback: function(/** @type {!ContextMenuRegistry.Scope} */
+      callback: function(/** @type {!GoogleBlockly.ContextMenuRegistry.Scope} */
                          scope) {
         scope.block.setDeletable(!this.isDeletable());
       },
-      scopeType: ContextMenuRegistry.ScopeType.BLOCK,
+      scopeType: GoogleBlockly.ContextMenuRegistry.ScopeType.BLOCK,
       id: 'blockDeletable',
       weight: 1,
     };
-    ContextMenuRegistry.registry.register(deletableOption);
+    GoogleBlockly.ContextMenuRegistry.registry.register(deletableOption);
   };
 
 const registerAllContextMenuItems = function() {

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -28,6 +28,7 @@ import initializeBlocklyXml from './addons/cdoXml';
 import initializeCss from './addons/cdoCss';
 import {UNKNOWN_BLOCK} from './addons/unknownBlock';
 import UnusedBlocksManager from './addons/unusedBlocksManager';
+import {registerAllContextMenuItems} from './addons/contextMenu';
 
 /**
  * Wrapper class for https://github.com/google/blockly
@@ -181,6 +182,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     true /* opt_allowOverrides */
   );
 
+  registerAllContextMenuItems();
   // These are also wrapping read only properties, but can't use wrapReadOnlyProperty
   // because the alias name is not the same as the underlying property name.
   Object.defineProperty(blocklyWrapper, 'mainBlockSpace', {


### PR DESCRIPTION
This moves the deletable context menu item out of BlockSvg and instead uses the [context menu registry](https://developers.google.com/blockly/guides/configure/web/context-menus).